### PR TITLE
Restrict python version to 2.7

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -300,45 +300,64 @@ ENDIF (PROTOBUF_FOUND
 
 MESSAGE(STATUS "${PROTOBUF_DIR_MESSAGE}")
 
-# Python needed for ... I'm not sure what. Something.
-FIND_PACKAGE(PythonInterp 2.7 EXACT)
-FIND_PACKAGE(PythonLibs 2.7 EXACT)
-IF(PYTHONLIBS_FOUND)
-	MESSAGE(STATUS "Python libs found.")
-ELSE(PYTHONLIBS_FOUND)
-	MESSAGE(STATUS "Python libs NOT found.")
-ENDIF(PYTHONLIBS_FOUND)
+# -----------------------------------------------------------------------------
+# Python and Cython
+#
+# NOTE: Python interpreter is needed for runing python unit tests, and for
+# running the FindCython and FindCxxtest cmake modules.
 
-# Python bindings using Cython
-# Cython is used to generate bindings
-FIND_PACKAGE(Cython 0.19.0)
-IF (CYTHON_FOUND AND PYTHONLIBS_FOUND)
-	# find python destination dir for python bindings
-	ADD_DEFINITIONS(-DHAVE_CYTHON)
-	SET(HAVE_CYTHON 1)
-	EXECUTE_PROCESS(
-		COMMAND ${PYTHON_EXECUTABLE} -c "from distutils.sysconfig import *;print(get_python_lib())"
-		OUTPUT_VARIABLE PYTHON_DEST
-	)
+FIND_PACKAGE(PythonInterp 2.7)
+IF (2.7.0 VERSION_LESS ${PYTHON_VERSION_STRING} AND
+	3.0.0 VERSION_GREATER ${PYTHON_VERSION_STRING})
+	SET (HAVE_PY_INTERP 1)
+	MESSAGE(STATUS "Python ${PYTHON_VERSION_STRING} interpreter found.")
+ENDIF()
 
-	# replace new line at end
-	STRING(REPLACE "\n" "" PYTHON_DEST "${PYTHON_DEST}")
-	IF ("${PYTHON_DEST}" STREQUAL "")
-		MESSAGE(FATAL_ERROR "Python destination dir not found")
-	ELSE ("${PYTHON_DEST}" STREQUAL "")
-		MESSAGE(STATUS "Python destination dir found: ${PYTHON_DEST}" )
-	ENDIF ("${PYTHON_DEST}" STREQUAL "")
-ELSE (CYTHON_FOUND AND PYTHONLIBS_FOUND)
-	IF(NOT CYTHON_FOUND)
-		MESSAGE(STATUS "Cython executable not found.")
-	ENDIF(NOT CYTHON_FOUND)
-ENDIF (CYTHON_FOUND AND PYTHONLIBS_FOUND)
+FIND_PACKAGE(PythonLibs 2.7)
+IF (PYTHONLIBS_FOUND AND
+	2.7.0 VERSION_LESS ${PYTHONLIBS_VERSION_STRING} AND
+	3.0.0 VERSION_GREATER ${PYTHONLIBS_VERSION_STRING})
+	SET (HAVE_PY_LIBS 1)
+	MESSAGE(STATUS "Python ${PYTHONLIBS_VERSION_STRING} libraries found.")
+ELSE()
+	MESSAGE(STATUS "Python libraries NOT found.")
+ENDIF()
 
-# Nosetests will find and automatically run python tests.
-FIND_PROGRAM(NOSETESTS_EXECUTABLE nosetests)
-IF (NOSETESTS_EXECUTABLE AND CYTHON_FOUND AND PYTHONLIBS_FOUND)
-	SET(HAVE_NOSETESTS 1)
-ENDIF (NOSETESTS_EXECUTABLE AND CYTHON_FOUND AND PYTHONLIBS_FOUND)
+# Cython is used to generate python bindings.
+IF(HAVE_PY_INTERP)
+	FIND_PACKAGE(Cython 0.19.0)
+
+	IF (CYTHON_FOUND AND HAVE_PY_LIBS)
+		# Find python destination dir for python bindings because it may
+		# differ on each operating system.
+		ADD_DEFINITIONS(-DHAVE_CYTHON)
+		SET(HAVE_CYTHON 1)
+		EXECUTE_PROCESS(
+			COMMAND ${PYTHON_EXECUTABLE} -c "from distutils.sysconfig import *;print(get_python_lib())"
+			OUTPUT_VARIABLE PYTHON_DEST
+		)
+
+		# Replace new line at end.
+		STRING(REPLACE "\n" "" PYTHON_DEST "${PYTHON_DEST}")
+		IF ("${PYTHON_DEST}" STREQUAL "")
+			MESSAGE(FATAL_ERROR "Python destination dir not found")
+		ELSE ("${PYTHON_DEST}" STREQUAL "")
+			MESSAGE(STATUS "Python destination dir found: ${PYTHON_DEST}" )
+		ENDIF ("${PYTHON_DEST}" STREQUAL "")
+	ELSE (CYTHON_FOUND AND HAVE_PY_LIBS)
+		IF(NOT CYTHON_FOUND)
+			MESSAGE(STATUS "Cython executable not found.")
+		ENDIF(NOT CYTHON_FOUND)
+	ENDIF (CYTHON_FOUND AND HAVE_PY_LIBS)
+
+	# Nosetests will find and automatically run python tests.
+	FIND_PROGRAM(NOSETESTS_EXECUTABLE nosetests)
+	IF (NOSETESTS_EXECUTABLE AND CYTHON_FOUND AND HAVE_PY_LIBS)
+		SET(HAVE_NOSETESTS 1)
+	ENDIF (NOSETESTS_EXECUTABLE AND CYTHON_FOUND AND HAVE_PY_LIBS)
+ENDIF(HAVE_PY_INTERP)
+
+# -----------------------------------------------------------------------------
 
 # Glasgow Haskell compiler
 FIND_PACKAGE(Stack)


### PR DESCRIPTION
This should insure that python 2.7 is only used. Only tested it on python 3 virtual environment and opencog/opencog-dev:cli container. It runs all 112 tests in container, and lists `Python bindings` and `Python tests` as not to be built in the cmake output of the virtual environment. Please test on your system as a double check, and then merge https://github.com/opencog/atomspace/pull/1163.